### PR TITLE
Add new stopping condition 

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -200,17 +200,26 @@ abstract type ProjectionAlgorithm end
 
         # save_mttkrp(converge, mtkrp)
         cprank = ind(λ, 1)
-        if als.check isa FitCheck && verbose
+        if als.check isa FitCheck
+            if als.check.iter == 0
+                println("Warning: FitCheck is not enabled for $(als.mttkrp_alg) will run $(als.check.max_counter) iterations.")
+            end
+            als.check.iter += 1
+            if verbose
             inner_prod = (had_contract([als.target, dag.(factors)...], cprank) * dag(λ))[]
             partial_gram = [fact * dag(prime(fact; tags=tags(cprank))) for fact in factors];
             fact_square = ITensorCPD.norm_factors(partial_gram, λ)
             normResidual =
                 sqrt(abs(als.check.ref_norm * als.check.ref_norm + fact_square - 2 * abs(inner_prod)))
-            println("Accuracy: $(1.0 - normResidual / norm(als.check.ref_norm))")
+                println("$(dim(cprank))\t$(als.check.iter)\t$(1.0 - normResidual / norm(als.check.ref_norm))")
         end
-
-        # return check_converge(converge, factors, λ,  []; verbose)
+            if als.check.iter == als.check.max_counter
+                als.check.iter = 0
+            end
         return false
+    end
+
+        return check_converge(converge, factors, λ,  []; verbose)
     end
 
     ### With this solver we are going to compute sampling projectors for LS decomposition

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -206,18 +206,18 @@ abstract type ProjectionAlgorithm end
             end
             als.check.iter += 1
             if verbose
-            inner_prod = (had_contract([als.target, dag.(factors)...], cprank) * dag(λ))[]
-            partial_gram = [fact * dag(prime(fact; tags=tags(cprank))) for fact in factors];
-            fact_square = ITensorCPD.norm_factors(partial_gram, λ)
-            normResidual =
-                sqrt(abs(als.check.ref_norm * als.check.ref_norm + fact_square - 2 * abs(inner_prod)))
+                inner_prod = (had_contract([als.target, dag.(factors)...], cprank) * dag(λ))[]
+                partial_gram = [fact * dag(prime(fact; tags=tags(cprank))) for fact in factors];
+                fact_square = ITensorCPD.norm_factors(partial_gram, λ)
+                normResidual =
+                    sqrt(abs(als.check.ref_norm * als.check.ref_norm + fact_square - 2 * abs(inner_prod)))
                 println("$(dim(cprank))\t$(als.check.iter)\t$(1.0 - normResidual / norm(als.check.ref_norm))")
-        end
+            end
             if als.check.iter == als.check.max_counter
                 als.check.iter = 0
             end
-        return false
-    end
+            return false
+        end
 
         return check_converge(converge, factors, λ,  []; verbose)
     end

--- a/src/converge_checks/converge_checks.jl
+++ b/src/converge_checks/converge_checks.jl
@@ -2,5 +2,14 @@ using ITensors: diag_itensor, hadamard_product!
 using ITensors.NDTensors: tensor
 abstract type ConvergeAlg end
 
+function norm_factors(partial_gram::Vector, λ::ITensor)
+    had = copy(partial_gram[1])
+    for i = 2:length(partial_gram)
+        hadamard_product!(had, had, partial_gram[i])
+    end
+    return (had*(λ*dag(prime(λ))))[]
+end
+
 include("no_check.jl")
 include("fit_check.jl")
+include("cp_diff_check.jl")

--- a/src/converge_checks/cp_diff_check.jl
+++ b/src/converge_checks/cp_diff_check.jl
@@ -1,0 +1,73 @@
+## In this code I will compute the norm difference between two CP 
+## approximations from consequtive iterations. If the distance is small the 
+## calculation is stopped. 
+## || \hat{T}_{n} - \hat{T}_{n-1} || / || \hat{T}_{n-1} || < ϵ 
+
+mutable struct CPDiffCheck <: ConvergeAlg
+    iter::Int
+    counter::Int
+    tolerance::Number
+    max_counter::Int
+    norm_prev_iter::Number
+    PrevCP
+    lastfit::Number
+    final_fit::Number
+
+    CPDiffCheck(tol, max) = new(0, 0, tol, max, 0.0, nothing, 1, 0)
+end
+
+function check_converge(check::CPDiffCheck, factors, λ, partial_gram; verbose = true)
+    check.iter += 1
+    rank = ind(λ, 1)
+
+    if isnothing(check.PrevCP)
+        check.PrevCP = CPD{ITensor}(prime.(factors; tags=tags(rank)), prime(λ))
+        check.norm_prev_iter  = norm_factors([i * prime(i; tags=tags(rank)) for i in factors], λ)
+        return false
+    end
+
+    currCP = CPD{ITensor}(factors, λ)
+    inner_prod = (check.PrevCP.λ * cp_cp_contract(check.PrevCP, currCP)[1] * λ)[]
+    #sum(hadamard_product(check.MttKRP, had_contract(dag(factors[end]), dag(λ), rank)))
+    fact_square = norm_factors([i * prime(i; tags=tags(rank)) for i in factors], λ)
+    normResidual =
+        sqrt(abs(check.norm_prev_iter + fact_square - 2 * abs(inner_prod)))
+    curr_fit = 1.0 - (normResidual / check.norm_prev_iter)
+    Δfit = abs(check.lastfit - curr_fit)
+    check.lastfit = curr_fit
+
+    check.PrevCP = CPD{ITensor}(prime.(factors; tags=tags(rank)), prime(λ))
+    check.norm_prev_iter  = fact_square
+
+    if (verbose)
+        println("$(dim(rank))\t $(check.iter) \t $(curr_fit) \t $(Δfit)")
+    end
+
+    if Δfit < check.tolerance
+        check.counter += 1
+        if check.counter >= 2
+            check.iter = 0
+            check.counter = 0
+            check.final_fit = check.lastfit
+            check.lastfit = 0
+            check.PrevCP = nothing
+            return true
+        end
+    else
+        check.counter = 0
+    end
+
+    if check.iter == check.max_counter
+        check.iter = 0
+        check.counter = 0
+        check.final_fit = check.lastfit
+        check.lastfit = 0
+        check.PrevCP = nothing
+    end
+
+    return false
+end
+
+CPDFit(check::CPDiffCheck) = check.final_fit
+
+function save_mttkrp(::CPDiffCheck, ::ITensor) end

--- a/src/converge_checks/fit_check.jl
+++ b/src/converge_checks/fit_check.jl
@@ -1,3 +1,7 @@
+## In this code I will compute the Fit (norm difference) between a CP and the true tensor.
+##  If the distance between two consecutive fits are small, the calculation is stopped.
+## || T - \hat{T}_{n} || / || T || < ϵ 
+
 mutable struct FitCheck <: ConvergeAlg
     iter::Int
     counter::Int
@@ -50,14 +54,6 @@ function check_converge(check::FitCheck, factors, λ, partial_gram; verbose = tr
     end
 
     return false
-end
-
-function norm_factors(partial_gram::Vector, λ::ITensor)
-    had = copy(partial_gram[1])
-    for i = 2:length(partial_gram)
-        hadamard_product!(had, had, partial_gram[i])
-    end
-    return (had*(λ*dag(prime(λ))))[]
 end
 
 CPDFit(check::FitCheck) = check.final_fit

--- a/src/cpd.jl
+++ b/src/cpd.jl
@@ -10,6 +10,8 @@ struct CPD{TargetT}
     inds::Vector{Index}
 end
 
+CPD() = CPD{nothing}(Vector{ITensor}(), ITensor(), Vector{Index}())
+
 function CPD{TargetT}(factors::Vector{ITensor}, λ::ITensor) where {TargetT}
     is = [ind(x, 1) for x in factors]
     CPD{TargetT}(factors, λ, is)

--- a/src/math_tools/probability.jl
+++ b/src/math_tools/probability.jl
@@ -10,11 +10,11 @@ function compute_leverage_score_probabilitiy(A, row::Index)
 end
 
 function samples_from_probability_vector(PW::Vector, samples)
-  return Vector{Int}([sample([x for x in 1:length(PW)], Weights(PW)) for i in 1:samples])
+  return Vector{Int}([sample([x for x in 1:length(PW)], Weights(abs.(PW))) for i in 1:samples])
 end
 
 function sample_single_col_from_factors(skip_factor, probs)
-  return [sample([x for x in 1:length(prob)], Weights(prob)) for prob in probs[1:end .!= skip_factor]]
+  return [sample([x for x in 1:length(prob)], Weights(abs.(prob))) for prob in probs[1:end .!= skip_factor]]
 end
 ## uniform sampling of each factor matrix (no blocking)
 ## nsamps = Number of samples 

--- a/test/standard_cpd.jl
+++ b/test/standard_cpd.jl
@@ -3,7 +3,9 @@
     i, j, k = Index.((20, 30, 40))
     r = Index(400, "CP_rank")
     A = random_itensor(elt, i, j, k)
+
     ## Calling decompose
+    
     opt_A = ITensorCPD.decompose(A, r);
     @test norm(reconstruct(opt_A) - A) / norm(A) < 1e-7
 
@@ -62,34 +64,36 @@
     
     ## This tests to see if we can interpolate a known low rank tensor
     A = ITensorCPD.reconstruct(random_CPD(A, 20))
+    check = ITensorCPD.CPDiffCheck(1e-5, 100)
 
     cp_A = random_CPD(A, 10)
-    opt_A = ITensorCPD.als_optimize(A, cp_A; check=ITensorCPD.FitCheck(1e-3, 100, norm(A)), verbose=true);
+    opt_A = ITensorCPD.als_optimize(A, cp_A; check, verbose);
     exact_error = norm(A - ITensorCPD.reconstruct(opt_A)) / norm(A)
     int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check=ITensorCPD.NoCheck(20));
+        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.01
 
     ### Test for Leverage score sampling CPD 
     a,b,c = Index.((12,13,3))
-    T = random_itensor(a,b,c)
+    T = random_itensor(elt, a,b,c)
 
     cpdT = random_CPD(T, 5)
     T = reconstruct(cpdT)
 
     cpd = random_CPD(T, 5)
     alg = ITensorCPD.LevScoreSampled()
-    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg);
+    check = ITensorCPD.CPDiffCheck(1e-5, 10)
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, verbose);
 
     alg = ITensorCPD.LevScoreSampled(100)
-    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg);
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, verbose);
     @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
 
     ### Test for Leverage score sampling CPD 
     alg = ITensorCPD.LevScoreSampled((50, 50, 500))
     min_val = 1
     for i in 1:3
-        cpd_opt = ITensorCPD.als_optimize(T, cpd; alg);
+        cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, verbose);
         val = norm(reconstruct(cpd_opt) - T) / norm(T) 
         min_val = val < min_val ? val : val
     end
@@ -138,6 +142,22 @@ end
 
     opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct(), check)
     @test norm(ITensorCPD.reconstruct(opt_A) - A) / norm(A) < 5e-5
+
+    ### Test for Leverage score sampling CPD 
+    a,b,c = Index.((12,13,3))
+    T = random_itensor(elt, a,b,c)
+
+    cpdT = random_CPD(T, 5)
+    T = reconstruct(cpdT)
+
+    cpd = random_CPD(T, 5)
+    alg = ITensorCPD.LevScoreSampled()
+    check = ITensorCPD.CPDiffCheck(1e-5, 10)
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, verbose);
+
+    alg = ITensorCPD.LevScoreSampled(100)
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, verbose);
+    @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
 end
 
 


### PR DESCRIPTION
Stopping condition established in https://pubs.acs.org/doi/abs/10.1021/acs.jctc.5c00413. Looks at the L2 difference between two consecutive CPD iterations.  When the distance between two iterations is small, the ALS is concluded. This fixes the issue of stopping condition for solvers that do not explicitly compute canonical MTtKRP and takes advantage of the KRP structure of the CPD approximations for efficient evaluation.