### PR TITLE
Multi-Index General Contract

### DIFF
--- a/src/converge_checks/cp_angle_check.jl
+++ b/src/converge_checks/cp_angle_check.jl
@@ -12,8 +12,9 @@ mutable struct CPAngleCheck <: ConvergeAlg
     PrevCP
     lastangle::Number
     final_fit::Number
+    total_iter::Int
 
-    CPAngleCheck(tol, max) = new(0, 0, tol, max, 0.0, nothing, 1, 0)
+    CPAngleCheck(tol, max) = new(0, 0, tol, max, 0.0, nothing, 1, 0, 0)
 end
 
 function check_converge(check::CPAngleCheck, factors, λ, partial_gram; verbose = true)
@@ -47,6 +48,7 @@ function check_converge(check::CPAngleCheck, factors, λ, partial_gram; verbose 
     if Δfit < check.tolerance
         check.counter += 1
         if check.counter >= 2
+            check.total_iter = check.iter
             check.iter = 0
             check.counter = 0
             check.final_fit = check.lastangle
@@ -59,6 +61,7 @@ function check_converge(check::CPAngleCheck, factors, λ, partial_gram; verbose 
     end
 
     if check.iter == check.max_counter
+        check.total_iter = check.iter
         check.iter = 0
         check.counter = 0
         check.final_fit = check.lastangle

--- a/src/converge_checks/cp_diff_check.jl
+++ b/src/converge_checks/cp_diff_check.jl
@@ -12,8 +12,9 @@ mutable struct CPDiffCheck <: ConvergeAlg
     PrevCP
     lastfit::Number
     final_fit::Number
+    total_iter::Int
 
-    CPDiffCheck(tol, max) = new(0, 0, tol, max, 0.0, nothing, 1, 0)
+    CPDiffCheck(tol, max) = new(0, 0, tol, max, 0.0, nothing, 1, 0, 0)
 end
 
 function check_converge(check::CPDiffCheck, factors, λ, partial_gram; verbose = true)
@@ -45,6 +46,7 @@ function check_converge(check::CPDiffCheck, factors, λ, partial_gram; verbose =
     if Δfit < check.tolerance
         check.counter += 1
         if check.counter >= 2
+            check.total_iter = check.iter
             check.iter = 0
             check.counter = 0
             check.final_fit = check.lastfit
@@ -57,6 +59,7 @@ function check_converge(check::CPDiffCheck, factors, λ, partial_gram; verbose =
     end
 
     if check.iter == check.max_counter
+        check.total_iter = check.iter
         check.iter = 0
         check.counter = 0
         check.final_fit = check.lastfit

--- a/src/converge_checks/fit_check.jl
+++ b/src/converge_checks/fit_check.jl
@@ -11,10 +11,11 @@ mutable struct FitCheck <: ConvergeAlg
     MttKRP::ITensor
     lastfit::Number
     final_fit::Number
+    total_iter::Int
 
     function FitCheck(tol, max, norm)
         elt = real(typeof(norm))
-         new(zero(elt), zero(elt), tol, max, norm, ITensor(), one(elt), zero(elt))
+         new(zero(elt), zero(elt), tol, max, norm, ITensor(), one(elt), zero(elt), zero(elt))
     end
 end
 
@@ -42,6 +43,7 @@ function check_converge(check::FitCheck, factors, λ, partial_gram; verbose = tr
     if Δfit < check.tolerance
         check.counter += 1
         if check.counter >= 2
+            check.total_iter= check.iter
             check.iter = 0
             check.counter = 0
             check.final_fit = check.lastfit
@@ -53,6 +55,7 @@ function check_converge(check::FitCheck, factors, λ, partial_gram; verbose = tr
     end
 
     if check.iter == check.max_counter
+        check.total_iter= check.iter
         check.iter = 0
         check.counter = 0
         check.final_fit = check.lastfit

--- a/test/contract_algs.jl
+++ b/test/contract_algs.jl
@@ -46,3 +46,78 @@ end
   @test 1 - norm(cpdB[] * had_contract([Acore, res[3].factors...], ITensorCPD.cp_rank(cpdB)) - (A * B)) ≈ 1
 end
 
+@testset "Multi-index had_contract" begin
+  i,j,k,l,m = Index.((10,9,8,7,3))
+  ## One mode contract mat * vec
+  A = random_itensor(i,j,k)
+  B = random_itensor(j,i,l,k)
+
+  Chad = ITensorCPD.had_contract(A, B, j,k)
+  C = zeros(Float64, dim(l),dim(j),dim(k))
+  for jj in 1:dim(j)
+    for kk in 1:dim(k)
+      for ll in 1:dim(l)
+        for ii in 1:dim(i)
+          C[ll,jj,kk] += array(A)[ii,jj,kk] * array(B)[jj,ii,ll,kk]
+        end
+      end
+    end
+  end
+
+  @test array(Chad, l,j,k) ≈ C
+
+  ## One mode contract mat * mat
+   A = random_itensor(i,m,j,k)
+  B = random_itensor(j,i,l,k)
+
+  Chad = ITensorCPD.had_contract(A, B, j,k)
+  C = zeros(Float64, dim(l), dim(m),dim(j),dim(k))
+  for jj in 1:dim(j)
+    for kk in 1:dim(k)
+      for ll in 1:dim(l)
+        for mm in 1:dim(m)
+          for ii in 1:dim(i)
+            C[ll,mm,jj,kk] += array(A)[ii,mm,jj,kk] * array(B)[jj,ii,ll,kk]
+          end
+        end
+      end
+    end
+  end
+
+  @test array(Chad, l,m,j,k) ≈ C
+
+   A = random_itensor(i,j,k)
+  B = random_itensor(j,l,k)
+
+  ## Outer product
+  Chad = ITensorCPD.had_contract(A, B, j,k)
+  C = zeros(Float64, dim(i), dim(l),dim(j),dim(k))
+  for jj in 1:dim(j)
+    for kk in 1:dim(k)
+      for ll in 1:dim(l)
+        for ii in 1:dim(i)
+          C[ii,ll,jj,kk] = array(A)[ii,jj,kk] * array(B)[jj,ll,kk]
+        end
+      end
+    end
+  end
+
+  @test array(Chad, i,l,j,k) ≈ C
+
+  A = random_itensor(i,j,k)
+  B = random_itensor(j,i,k)
+
+  ## Inner product
+  Chad = ITensorCPD.had_contract(A, B, j,k)
+  @show Chad
+  C = zeros(Float64, dim(j),dim(k))
+  for jj in 1:dim(j)
+    for kk in 1:dim(k)
+      for ii in 1:dim(i)
+        C[jj,kk] += array(A)[ii,jj,kk] * array(B)[jj,ii,kk]
+      end
+    end
+  end
+
+  @test array(Chad, j,k) ≈ C
+end


### PR DESCRIPTION
The had_contract function is a general tensor product that allows general einsum indices. The product divides the problem into batched contractions which are computed efficiently. Currently the algorithm doesn't support multiple non-covarient indices. This algorithm allows one to had_contract over multiple hadamard indices. The algorithm first permutes all the indices together and then fuses the had indices into a compound index which can then call the single-index had_contract function.
This algorithm currently "works" though future implementations should consider leveraging strides for memory efficiency.