### PR TITLE
Change sampling from matrix index to tensor index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorCPD"
 uuid = "8ca0d870-8743-11ef-3aad-a3ebf6911431"
 authors = ["Karl Pierce <kpierce@flatironinstitute.org>"]
-version = "0.0.7"
+version = "0.0.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -9,6 +9,7 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 ITensorNetworks = "2919e153-833c-4bdc-8836-1ea460a35fc7"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -23,7 +24,7 @@ Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 ITCPDMetalExt = ["Metal"]
 
 [compat]
-ITensorNetworks = "0.18.1"
+ITensorNetworks = "0.18"
 LinearAlgebra = "1.10.0"
 StatsBase = "0.34.6"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 ITCPDMetalExt = ["Metal"]
 
 [compat]
-ITensorNetworks = "0.18"
+ITensorNetworks = "0.18,0.15"
 LinearAlgebra = "1.10.0"
 StatsBase = "0.34.6"
 julia = "1.10"

--- a/src/ITensorCPD.jl
+++ b/src/ITensorCPD.jl
@@ -2,6 +2,9 @@ module ITensorCPD
   cholesky_epsilon = 1e-6
   check_angle = false
 
+  ## TODO Add OhMyThreads to serial algorithms that could be trivially parallelized.
+  using OhMyThreads
+
   include("math_tools/row_norm.jl")
   include("converge_checks/converge_checks.jl")
   include("algebra/had_contract.jl")

--- a/src/algebra/SEQRCS.jl
+++ b/src/algebra/SEQRCS.jl
@@ -197,8 +197,6 @@ function SEQRCS(krp::Vector{ITensor},i,l,s,t; compute_r=true, use_omega=false, i
     
     _, _, p_sk = qr!(copy(array(A_sk)'), ColumnNorm())  
     
-    ## TODO working here. This can be threadwise parallelized which
-    ## Will help with the cost. 
     indices = Vector{Int}()
     p_sk=p_sk[1:t]
 
@@ -208,6 +206,8 @@ function SEQRCS(krp::Vector{ITensor},i,l,s,t; compute_r=true, use_omega=false, i
     omega = nothing;
     indices = findall(col -> any(!=(0), col), eachcol(rows_sel))
     indices_ind = Index(length(indices),"ind")
+    indices_tensor = itensor(Int, column_to_multi_coords(indices, dims(Ris)), (indices_ind, Index(length(Ris))))
+    
     println("The size of A_subset is $(length(indices))")
 
     ## Perform QR on A_subset to get final 'k' pivots
@@ -216,10 +216,9 @@ function SEQRCS(krp::Vector{ITensor},i,l,s,t; compute_r=true, use_omega=false, i
     # mode = length(inds(A))
     # Q, R, p_subset = qr!(array(fused_flatten_sample(A, mode, indices_tensor)), ColumnNorm()) 
 
-    indices_tensor = itensor(tensor(Diag(indices), (Ris..., indices_ind)))
     ## TODO is there a way to lazy permute?
-    Q, R, p_subset = qr!(copy(array(pivot_hadamard(krp, ind(krp[1], 2), indices_tensor))'), ColumnNorm())
-    
+    ffkrpn = array(pivot_hadamard(krp, i, indices_tensor))
+    Q, R, p_subset = qr!(ffkrpn', ColumnNorm())
     rem_indices = setdiff(1:n,indices)
     p = vcat(indices[p_subset],rem_indices)
 

--- a/src/algebra/SEQRCS.jl
+++ b/src/algebra/SEQRCS.jl
@@ -190,6 +190,7 @@ function SEQRCS(krp::Vector{ITensor},i,l,s,t; compute_r=true, use_omega=false, i
     ## TODO remove the need for full omega, use efficient representation.
     omega = sparse_sign_matrix(l,n,s, Array{Int32}(undef, n * s), Array{Float64}(undef, n * s); omega=true,injective=injective)
 
+
     # Sketch the matrix and applying QR 
     A_sk = omega_hadamard(krp, cprank, omega)
     println("The size of A_sk is $(size(A_sk))")

--- a/src/algebra/had_contract.jl
+++ b/src/algebra/had_contract.jl
@@ -259,31 +259,16 @@ function pivot_hadamard(A::ITensor, B::ITensor, had::Index, pivots::ITensor)
 
     i = ind(A,1)
     j = ind(B,1)
-    npivs = column_to_multi_coords(data(pivots), dim.((i,j)))
+    npivs = array(pivots)
 
-    return itensor((array(A)[npivs[:,1], :] .* array(B)[npivs[:,2], :]), inds(pivots)[end], had)
+    return itensor((array(A)[npivs[:,1], :] .* array(B)[npivs[:,2], :]), inds(pivots)[1], had)
 end
 
 ## This function is special tensor product derived from the khatri-rao product
 ## each tensor must be a matrix with one matching mode. See above for a full description.
 ## This function works for a list of tensors to be fused via the Khatri-Rao product.
 function pivot_hadamard(tensors, had::Index, pivots::ITensor)
-    for tensor in tensors
-        @assert had == ind(tensor, 2)
-    end
-
-    ## Right now assume only one common ind.
-    is = [commonind(pivots,x) for x in tensors]
-
-    npivs = column_to_multi_coords(data(pivots), dim.(is))
-    arrayT =typeof(array(tensors[1]))
-    prod = arrayT(ones(eltype(tensors[1]), size(npivs)[1], dim(had)))
-
-    for (tensor, i) in zip(tensors, eachcol(npivs))
-        @inbounds prod .*= (@view array(tensor)[i, :])
-    end
-    
-    return itensor(prod, inds(pivots)[end], had)
+    return pivot_hadamard(tensors, had, array(pivots), ind(pivots, 1))
 end
 ## This function is special tensor product derived from the khatri-rao product
 ## each tensor must be a matrix with one matching mode. See above for a full description.
@@ -295,16 +280,20 @@ function pivot_hadamard(tensors, had::Index, pivots::Matrix, piv_ind::Union{<:No
     end
 
     npivs = size(pivots)[1]
+
     arrayT =typeof(array(tensors[1]))
     prod = arrayT(ones(eltype(tensors[1]), npivs, dim(had)))
+
     for (tensor, i) in zip(tensors, eachcol(pivots))
-        @inbounds m = @view array(tensor)[i, :]
-        prod .*= m
+        prod .*= @inbounds @view array(tensor)[i, :]
+        ## TODO convert this to a tmap function 
+        # tmap!(x-> (slices[x...]), cols, pivs)
     end
     
     piv_ind = isnothing(piv_ind) ? Index(npivs, "PivIdx") : piv_ind
     return itensor(prod, piv_ind, had)
 end
+
 ## This function works on a list of tensors and a sparse matrix omega 
 ## to directly sketch the Khatri–Rao product
 ## All the tesnors should be matrices

--- a/src/algebra/had_contract.jl
+++ b/src/algebra/had_contract.jl
@@ -309,6 +309,7 @@ function omega_hadamard(tensors, had::Index, omega)
 
     dis = dim.(is)
     omega_slice = eachrow(omega)
+    
     ## When I create an iterator over eachrow, the total number of sampled cols goes down and the
     ## Error in the QR changes marginally. Not sure why so not going to do this step now.
     for (j, os) in zip(1:l, omega_slice)
@@ -318,9 +319,9 @@ function omega_hadamard(tensors, had::Index, omega)
         kr_prod = ones(eltype(tensors[1]), size(npivs,1), dim(had))
         signs = os[nnz_ind]
         for (tensor, i) in zip(tensors, eachcol(npivs))
-            kr_prod .*= (@view array(tensor)[i, :]) .* signs[:,]
+            kr_prod .*= (@view array(tensor)[i, :])
         end
-        s_prod[j,:] = sum(kr_prod, dims=1)
+        s_prod[j,:] = sum(kr_prod .* signs[:,], dims=1)
         #sslice = sum(kr_prod, dims=1)
     end
 

--- a/src/algebra/pivot_mapping.jl
+++ b/src/algebra/pivot_mapping.jl
@@ -54,14 +54,12 @@ function transform_alpha_to_vectorized_tensor_position(α, extent, stride)::Int
   return T * stride * extent + (α - T * stride)
 end
 
-## TODO Add OhMyThreads to serial algorithms that could be trivially parallelized.
-# using OhMyThreads
 ## This function will take a higher-order tensor and a list of pivots
 ## and matricizes it along the `k`the dimension returning a matrix of size dim(k) x num_samples
 function fused_flatten_sample(T::ITensor, k::Int, pivots::ITensor)
   # v = vec(NDTensors.data(T))
   idx = ind(T, k)
-  As = similar(T, (idx, inds(pivots)[end]))
+  As = similar(T, (idx, inds(pivots)[1]))
   # stride = strides(T.tensor)[k]
   # pos = map(x -> ITensorCPD.transform_alpha_to_vectorized_tensor_position(x, dim(idx), stride), NDTensors.data(pivots))
   ## Not sure which is faster
@@ -75,11 +73,12 @@ function fused_flatten_sample(T::ITensor, k::Int, pivots::ITensor)
   @inbounds dims = [1:ndims(T)...][1:end .!= k]
   slices = eachslice(array(T); dims=Tuple(dims))
   cols = eachcol(array(As))
-  pivs = NDTensors.data(pivots);
+  pivs = Tuple.(eachrow(array(pivots)));
+
   ## TODO add a check to see if threads > 1 && using LazyFunctionTensor && function of tensor is Python.
   ## This will cause a break.
-  # tmap!(x-> (slices[x]), cols, pivs)
-  map!(x-> (slices[x]), cols, pivs)
+  tmap!(x-> (slices[x...]), cols, pivs)
+  # map!(x-> (slices[x]), cols, pivs)
   # @inbounds eachcol(array(As)) .= Array.(slices[pivs])
 
   return As
@@ -97,7 +96,7 @@ function  sketched_matricization(T::ITensor, k::Int, omega)
   stride = strides(T.tensor)[k]
   for j in 1:l
     m = @inbounds omega[j,:];
-    pos = map(x -> ITensorCPD.transform_alpha_to_vectorized_tensor_position(x, dim(idx), stride), m.nzind)
+    pos = tmap(x -> ITensorCPD.transform_alpha_to_vectorized_tensor_position(x, dim(idx), stride), m.nzind)
     ## Shouldn't we multiply by + or - 1 based on the sign of omega here?
     As_slice[j] .= [sum((@view v[pos .+ stride* (i-1)]) .* m.nzval) for i in 1:dim(idx)]
   end
@@ -129,12 +128,13 @@ function  sketched_matricization(T::ITensor, k::Int, l, rows, vals, s)
     dict_rows[i] = Vector{Int}()
   end
   map((i,j) -> push!(dict_rows[i], j), rows, range(1,length(rows)))
+  
   for (x, j) in zip(As_slice, 1:l)
     nzs = @inbounds dict_rows[j]
-    pos = map(x -> ITensorCPD.transform_alpha_to_vectorized_tensor_position(x, didx, stride),
+    pos = tmap(x -> ITensorCPD.transform_alpha_to_vectorized_tensor_position(x, didx, stride),
                        nzs .÷ s + map(i -> i % s > 0 ? 1 : 0, nzs))
     m2 = @inbounds @view vals[nzs]
-    @inbounds x .= map(i -> dot((@inbounds @view v[pos .+ stride* (i-1)]), m2), 1:didx)
+    @inbounds x .= tmap(i -> dot((@inbounds @view v[pos .+ stride* (i-1)]), m2), 1:didx)
   end
   return As
 end 

--- a/src/algorithms/ALS/randomized/ProjectionAlgorithm.jl
+++ b/src/algorithms/ALS/randomized/ProjectionAlgorithm.jl
@@ -44,7 +44,7 @@ abstract type ProjectionAlgorithm end
 
                 println("$(dim(cprank))\t$(als.check.iter)\t$(cpfit)")
             end
-            if als.check.iter > als.check.max_counter
+            if als.check.iter >= als.check.max_counter
                 als.check.iter = 0
             end
             return false

--- a/src/algorithms/ALS/randomized/krp_lev_score_sampled.jl
+++ b/src/algorithms/ALS/randomized/krp_lev_score_sampled.jl
@@ -26,9 +26,10 @@ end
         if resample
             sampled_cols = sample_factor_matrices(nsamps, fact, als.additional_items[:factor_weights])
             ## Write new samples to pivot tensor
-            data(als.additional_items[:projects_tensors][fact]) .= multi_coords_to_column(dRis, sampled_cols)
+            
+            array(als.additional_items[:projects_tensors][fact]) .= sampled_cols
         else
-            sampled_cols = column_to_multi_coords(data(als.additional_items[:projects_tensors][fact]), dRis)
+            sampled_cols = array(als.additional_items[:projects_tensors][fact])
         end
         
         return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[1])
@@ -84,16 +85,15 @@ end
 
         resample = als.additional_items[:stop_resample]
         resample = resample < 0 || resample > iter(als)
-        dRis = dims(inds(cp)[1:end .!= fact])
         if resample
             sampled_cols = block_sample_factor_matrices(nsamps, als.additional_items[:factor_weights], block_size, fact)
             ## Write new samples to pivot tensor
-            data(als.additional_items[:projects_tensors][fact]) .= multi_coords_to_column(dRis, sampled_cols)
+            array(als.additional_items[:projects_tensors][fact]) .= sampled_cols
         else
-            sampled_cols = column_to_multi_coords(data(als.additional_items[:projects_tensors][fact]), dRis)
+            sampled_cols = array(als.additional_items[:projects_tensors][fact])
         end
         
-        return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[end])
+        return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[1])
     end
 
     function matricize_tensor(::BlockLevScoreSampled, als, factors, cp, rank::Index, fact::Int)

--- a/src/algorithms/ALS/randomized/qr_lev_score_sampled.jl
+++ b/src/algorithms/ALS/randomized/qr_lev_score_sampled.jl
@@ -105,16 +105,16 @@ const PivotBasedSolvers = Union{QRPivProjected, SEQRCSPivProjected, KSEQRCSPivPr
         effective_ranks = als.additional_items[:effective_ranks]
         for (p,pos, projector_tensor, meff, m) in zip(ref_pivs,1:length(pivots), projectors, effective_ranks, dims(als.target))
             ## This is reshuffling the indices
+            Ris = inds(target)[1:end .!= pos]
             if reshuffle
                 p1 = p[1:meff]
                 p_rest = p[meff+1:end]
                 p2 = p_rest[randperm(length(p_rest))]
                 pshuff = vcat(p1, p2)
                 
+                pshuff = column_to_multi_coords(pshuff, dims(Ris))
                 pivots[pos] = pshuff
             end
-
-            Ris = inds(projector_tensor)[1:end-1]
 
             dRis = dim(Ris)
             int_end = stop(updated_alg)
@@ -128,8 +128,9 @@ const PivotBasedSolvers = Union{QRPivProjected, SEQRCSPivProjected, KSEQRCSPivPr
 
             ndim = int_end - int_start + 1
             piv_id = Index(ndim, "pivot")
+            nind = Index(length(Ris))
 
-            projectors[pos] =  itensor(tensor(Diag(pivots[pos][int_start:int_end]), (Ris..., piv_id)))
+            projectors[pos] = itensor(Int, pivots[pos][int_start:int_end, :], (piv_id, nind))
 
             targets[pos] = fused_flatten_sample(target, pos, projectors[pos])
         end

--- a/src/algorithms/als/randomized/krp_lev_score_sampled.jl
+++ b/src/algorithms/als/randomized/krp_lev_score_sampled.jl
@@ -26,9 +26,10 @@ end
         if resample
             sampled_cols = sample_factor_matrices(nsamps, fact, als.additional_items[:factor_weights])
             ## Write new samples to pivot tensor
-            data(als.additional_items[:projects_tensors][fact]) .= multi_coords_to_column(dRis, sampled_cols)
+            
+            array(als.additional_items[:projects_tensors][fact]) .= sampled_cols
         else
-            sampled_cols = column_to_multi_coords(data(als.additional_items[:projects_tensors][fact]), dRis)
+            sampled_cols = array(als.additional_items[:projects_tensors][fact])
         end
         
         return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[1])
@@ -84,16 +85,15 @@ end
 
         resample = als.additional_items[:stop_resample]
         resample = resample < 0 || resample > iter(als)
-        dRis = dims(inds(cp)[1:end .!= fact])
         if resample
             sampled_cols = block_sample_factor_matrices(nsamps, als.additional_items[:factor_weights], block_size, fact)
             ## Write new samples to pivot tensor
-            data(als.additional_items[:projects_tensors][fact]) .= multi_coords_to_column(dRis, sampled_cols)
+            array(als.additional_items[:projects_tensors][fact]) .= sampled_cols
         else
-            sampled_cols = column_to_multi_coords(data(als.additional_items[:projects_tensors][fact]), dRis)
+            sampled_cols = array(als.additional_items[:projects_tensors][fact])
         end
         
-        return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[end])
+        return pivot_hadamard(factors, rank, sampled_cols, inds(als.additional_items[:projects_tensors][fact])[1])
     end
 
     function matricize_tensor(::BlockLevScoreSampled, als, factors, cp, rank::Index, fact::Int)

--- a/src/converge_checks/cp_angle_check.jl
+++ b/src/converge_checks/cp_angle_check.jl
@@ -60,7 +60,7 @@ function check_converge(check::CPAngleCheck, factors, λ, partial_gram; verbose 
         check.counter = 0
     end
 
-    if check.iter > check.max_counter
+    if check.iter >= check.max_counter
         check.total_iter = check.iter
         check.iter = 0
         check.counter = 0

--- a/src/converge_checks/cp_diff_check.jl
+++ b/src/converge_checks/cp_diff_check.jl
@@ -58,7 +58,7 @@ function check_converge(check::CPDiffCheck, factors, λ, partial_gram; verbose =
         check.counter = 0
     end
 
-    if check.iter > check.max_counter
+    if check.iter >= check.max_counter
         check.total_iter = check.iter
         check.iter = 0
         check.counter = 0

--- a/src/converge_checks/fit_check.jl
+++ b/src/converge_checks/fit_check.jl
@@ -54,7 +54,7 @@ function check_converge(check::FitCheck, factors, λ, partial_gram; verbose = tr
         check.counter = 0
     end
 
-    if check.iter > check.max_counter
+    if check.iter >= check.max_counter
         check.total_iter= check.iter
         check.iter = 0
         check.counter = 0

--- a/src/converge_checks/no_check.jl
+++ b/src/converge_checks/no_check.jl
@@ -13,6 +13,7 @@ function check_converge(check::NoCheck, factors, λ, partial_gram; verbose = fal
         println("$(dim(rank))\t $(check.iter)")
     end
     if check.iter == check.max_counter
+        check.iter = 0
         return true
     end
     return false

--- a/src/decompose.jl
+++ b/src/decompose.jl
@@ -50,6 +50,7 @@ function decompose(
     check = isnothing(check) ? FitCheck(1e-3, 100, norm(A)) : check
     while true
         cpd = als_optimize(A, cpd; alg, check, maxiter, verbose, KWARGS...);
+        check.iter = 0
         if 1.0 - ITensorCPD.CPDFit(check) < epsilon
             return cpd
         else

--- a/src/math_tools/row_norm.jl
+++ b/src/math_tools/row_norm.jl
@@ -1,5 +1,5 @@
 using ITensors: ITensor, hadamard_product
-using ITensors.NDTensors: NDTensors
+using ITensors.NDTensors: NDTensors, Diag
 
 function row_norm(t::ITensor, i...)
     elt = eltype(t)

--- a/src/optimizers/ALS/als.jl
+++ b/src/optimizers/ALS/als.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra: ColumnNorm, diagm
-using ITensors.NDTensors:Diag
+using ITensors.NDTensors: Dense
 using ITensors: tags
 
 struct ALS <: CPDOptimizer

--- a/src/optimizers/ALS/optimize.jl
+++ b/src/optimizers/ALS/optimize.jl
@@ -5,7 +5,7 @@
 ## [out] A CPD object with optmiized ALS factors
 function optimize(cp::CPD, als::ALS; verbose = false)
     rank = cp_rank(cp)
-    iter = 0
+    iter = als.check.iter
 
     λ = deepcopy(cp.λ)
     factors = deepcopy(cp.factors)

--- a/src/optimizers/ALS/randomized/krp_lev_score_sampled.jl
+++ b/src/optimizers/ALS/randomized/krp_lev_score_sampled.jl
@@ -71,8 +71,7 @@ function compute_als(
         piv_ind = Index(nsamps, "selector_$(fact)")
 
         ## make the canonical pivot tensor. This list of pivots will be overwritten each ALS iteration
-        # push!(projects_tensors, itensor(tensor(Diag(sampled_tensor_cols), (Ris..., piv_ind))))
-        push!(projects_tensors, itensor(tensor(Dense(sampled_cols), (piv_ind, nind))))
+        push!(projects_tensors, itensor(Int, sampled_cols, (piv_ind, nind)))
     end
     ## Notice the pivot tensor is actually a low rank tensor it stores the diagonal pivot values
     ## in α form (rows of the matricized tensor) and the indices which are captured in the pivot.

--- a/src/optimizers/ALS/randomized/krp_lev_score_sampled.jl
+++ b/src/optimizers/ALS/randomized/krp_lev_score_sampled.jl
@@ -16,7 +16,6 @@ function compute_als(
     for fact in 1:length(cp)
         ## grab the tensor indices for all other factors but fact
         Ris = inds(cp)[1:end .!= fact]
-        dRis = dims(Ris)
 
         ## sample the factor matrix space one taking nsamps independent samples from each
         ## tensor
@@ -24,13 +23,13 @@ function compute_als(
         nsamps = length(nsamps) == 1 ? nsamps[1] : nsamps[fact]
         sampled_cols = sample_factor_matrices(nsamps, fact, extra_args[:factor_weights])
 
-        ## We store the rows of the flattened tensor (i.e. α) because it can be converted to factor values
-        ## or values in the vectorized tensor
-        sampled_tensor_cols = multi_coords_to_column(dRis, sampled_cols)
-        piv_ind = Index(length(sampled_tensor_cols), "selector_$(fact)")
+        ## We store the tensor-wise indices because storing the column position or the vectorized step position (α) 
+        ## because this value is limited by dim(Ris) which can overflow int64
+        nind = Index(length(Ris))
+        piv_ind = Index(nsamps, "selector_$(fact)")
 
         ## make the canonical pivot tensor. This list of pivots will be overwritten each ALS iteration
-        push!(projects_tensors, itensor(tensor(Diag(sampled_tensor_cols), (Ris..., piv_ind))))
+        push!(projects_tensors, itensor(tensor(Dense(sampled_cols), (piv_ind, nind))))
     end
     extra_args[:projects_tensors] = projects_tensors
     extra_args[:normal] = normal
@@ -56,7 +55,6 @@ function compute_als(
     for fact in 1:length(cp)
         ## grab the tensor indices for all other factors but fact
         Ris = inds(cp)[1:end .!= fact]
-        dRis = dims(Ris)
 
         ## sample the factor matrix space one taking nsamps independent samples from each
         ## tensor
@@ -67,13 +65,14 @@ function compute_als(
         
         sampled_cols = block_sample_factor_matrices(nsamps, extra_args[:factor_weights] , block_size, fact)
 
-        ## We store the rows of the flattened tensor (i.e. α) because it can be converted to factor values
-        ## or values in the vectorized tensor
-        sampled_tensor_cols = multi_coords_to_column(dRis, sampled_cols)
-        piv_ind = Index(length(sampled_tensor_cols), "selector_$(fact)")
+        ## We store the tensor-wise indices because storing the column position or the vectorized step position (α) 
+        ## because this value is limited by dim(Ris) which can overflow int64
+        nind = Index(length(Ris))
+        piv_ind = Index(nsamps, "selector_$(fact)")
 
         ## make the canonical pivot tensor. This list of pivots will be overwritten each ALS iteration
-        push!(projects_tensors, itensor(tensor(Diag(sampled_tensor_cols), (Ris..., piv_ind))))
+        # push!(projects_tensors, itensor(tensor(Diag(sampled_tensor_cols), (Ris..., piv_ind))))
+        push!(projects_tensors, itensor(tensor(Dense(sampled_cols), (piv_ind, nind))))
     end
     ## Notice the pivot tensor is actually a low rank tensor it stores the diagonal pivot values
     ## in α form (rows of the matricized tensor) and the indices which are captured in the pivot.

--- a/src/optimizers/ALS/randomized/qr_lev_score_sampled.jl
+++ b/src/optimizers/ALS/randomized/qr_lev_score_sampled.jl
@@ -159,8 +159,7 @@ function compute_als(
         piv_id = Index(ndim, "pivot")
         nind = Index(length(Ris))
 
-        # push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
-        push!(projectors, itensor(tensor(Dense(p[int_start:int_end, :]), (piv_id, nind))))
+        push!(projectors, itensor(Int, p[int_start:int_end, :], (piv_id, nind)))
         TP = fused_flatten_sample(target, n, projectors[n])
         
     push!(targets, TP)
@@ -265,8 +264,7 @@ function compute_als(
         piv_id = Index(ndim, "pivot")
         nind = Index(length(Ris))
 
-        # push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
-        push!(projectors, itensor(tensor(Dense(p[int_start:int_end, :]), (piv_id, nind))))
+        push!(projectors, itensor(Int, p[int_start:int_end, :], (piv_id, nind)))
         TP = fused_flatten_sample(target, n, projectors[n])
         
         push!(targets, TP)

--- a/src/optimizers/ALS/randomized/qr_lev_score_sampled.jl
+++ b/src/optimizers/ALS/randomized/qr_lev_score_sampled.jl
@@ -9,7 +9,7 @@ function compute_als(
     normal = true,
     kwargs...
 )
-    pivots = Vector{Vector{Int}}()
+    pivots = Vector{Matrix{Int}}()
     ref_pivs = Vector{Vector{Int}}()
     projectors = Vector{ITensor}()
     targets = Vector{ITensor}()
@@ -17,7 +17,6 @@ function compute_als(
     effective_ranks = Vector{Int}()
     piv_id = nothing
     for (i, n) in zip(inds(target), 1:length(cp))
-        
         Ris = uniqueinds(target, i)
         m = dim(i)
         Tmat = reshape(array(target, (i, Ris...)), (m, dim(Ris)))
@@ -25,11 +24,9 @@ function compute_als(
         dr = diag(r)
         r = nothing
         GC.gc()
-        #meff = sum(abs.(diag(r)) .> trunc_tol)
+
         meff = sum(abs.(dr) ./ maximum(abs.(dr)) .> trunc_tol)
         push!(effective_ranks, meff)
-        
-        #q,r,p = lu(Tmat', RowMaximum(), allowsingular=true)
         
         ### QR based inital guess strategy.
         idx = Index(m, "rank")
@@ -47,6 +44,7 @@ function compute_als(
         p = vcat(p1, p2)
 
         # p = randperm(dim(Ris))
+        p = column_to_multi_coords(p, dims(Ris))
         push!(pivots, p)
 
         dRis = dim(Ris)
@@ -62,7 +60,8 @@ function compute_als(
         ndim = int_end - int_start + 1
         piv_id = Index(ndim, "pivot")
 
-        push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
+        nind = Index(length(Ris))
+        push!(projectors, itensor(tensor(Dense(p[int_start:int_end, :]), (piv_id, nind))))
         TP = fused_flatten_sample(target, n, projectors[n])
         
         push!(targets, TP)
@@ -94,7 +93,7 @@ function compute_als(
     lst = isnothing(lst) ? [] : lst
     rank_sk = rank_vect(alg)
     ref_pivs = Vector{Vector{Int}}()
-    pivots = Vector{Vector{Int}}()
+    pivots = Vector{Matrix{Int}}()
     projectors = Vector{ITensor}()
     targets = Vector{ITensor}()
     qr_factors = Vector{AbstractArray}()
@@ -103,6 +102,7 @@ function compute_als(
     for (i, n) in zip(inds(target), 1:length(cp))
         Ris = uniqueinds(target, i)
 
+        ## TODO this will fail for large columns
         dRis = dim(Ris)
         int_end = stop(alg)
         int_end = length(int_end) == 1 ? int_end[1] : int_end[n]
@@ -120,10 +120,8 @@ function compute_als(
             ## TODO there is still a bug in this line below
             k_sk = isnothing(rank_sk) ? int_end : rank_sk[n]
             l=Int(round(3 * m * log(m)))
-            # l=Int(round(3 * m )) 
             s=Int(round(log(m)))
             q,r,p = SEQRCS(target,n,i,l,s,k_sk; compute_r = false, use_omega=false,injective = injective)
-            # p = vcat(p[1:m], p[m+1:end][randperm(end-m)])
         else
             Tmat = reshape(array(target, (i, Ris...)), (dim(i), dim(Ris)))
             q, r, p = qr(Tmat, ColumnNorm())
@@ -133,6 +131,7 @@ function compute_als(
         GC.gc()
 
         push!(ref_pivs, deepcopy(p))
+        # push!(ref_pivs, deepcopy(column_to_multi_coords(p, dims(Ris))))
 
         # meff = sum(abs.(diag(r)) ./ maximum(abs.(diag(r))) .> trunc_tol)
         meff = sum(abs.(dr) ./ maximum(abs.(dr)) .> trunc_tol)
@@ -142,6 +141,12 @@ function compute_als(
         p_rest = p[meff+1:end]
         p2 = shuffle_pivots ? p_rest[randperm(length(p_rest))] : p_rest
         p = vcat(p1, p2)
+
+        ## Convert P from column indices to factor wise indices
+        ## TODO right now the QR based solvers still fail for large tensors because
+        ## The column index may be out of range before this conversion. Will be working on that
+        ## problem a different time
+        p = column_to_multi_coords(p, dims(Ris))
         push!(pivots, p)
 
         ### QR based inital guess strategy.
@@ -152,8 +157,10 @@ function compute_als(
 
         ndim = int_end - int_start + 1
         piv_id = Index(ndim, "pivot")
+        nind = Index(length(Ris))
 
-        push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
+        # push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
+        push!(projectors, itensor(tensor(Dense(p[int_start:int_end, :]), (piv_id, nind))))
         TP = fused_flatten_sample(target, n, projectors[n])
         
     push!(targets, TP)
@@ -199,7 +206,7 @@ function compute_als(
     cprank = cp_rank(updated_cpd)
     rank_sk = rank_vect(alg)
     ref_pivs = Vector{Vector{Int}}()
-    pivots = Vector{Vector{Int}}()
+    pivots = Vector{Matrix{Int}}()
     projectors = Vector{ITensor}()
     targets = Vector{ITensor}()
     qr_factors = Vector{AbstractArray}()
@@ -224,7 +231,6 @@ function compute_als(
         ## very expensive. This works well so we need to figure out what size to make this variable.
         m = dim(i)
         if n in lst
-            ## TODO there is still a bug in this line below
             k_sk = isnothing(rank_sk) ? int_end : rank_sk[n]
             l=Int(round(3 * m * log(m)))
             # l=Int(round(3 * m )) 
@@ -241,6 +247,7 @@ function compute_als(
         r = nothing
         GC.gc()
 
+        # push!(ref_pivs, deepcopy(column_to_multi_coords(p, dims(Ris))))
         push!(ref_pivs, deepcopy(p))
 
         # meff = sum(abs.(diag(r)) ./ maximum(abs.(diag(r))) .> trunc_tol)
@@ -251,18 +258,15 @@ function compute_als(
         p_rest = p[meff+1:end]
         p2 = shuffle_pivots ? p_rest[randperm(length(p_rest))] : p_rest
         p = vcat(p1, p2)
+        p = column_to_multi_coords(p, dims(Ris))
         push!(pivots, p)
-
-        ### QR based inital guess strategy.
-        # idx = Index(m, "rank")
-        # qt = had_contract(itensor(copy(q), Index(m),idx), itensor(dr, idx), idx)
-        # q = array(qt)
-        # push!(qr_factors, q)
 
         ndim = int_end - int_start + 1
         piv_id = Index(ndim, "pivot")
+        nind = Index(length(Ris))
 
-        push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
+        # push!(projectors, itensor(tensor(Diag(p[int_start:int_end]), (Ris..., piv_id))))
+        push!(projectors, itensor(tensor(Dense(p[int_start:int_end, :]), (piv_id, nind))))
         TP = fused_flatten_sample(target, n, projectors[n])
         
         push!(targets, TP)

--- a/test/SEQRCS_test.jl
+++ b/test/SEQRCS_test.jl
@@ -57,8 +57,9 @@ end
     
     ## For some reason this code fails. Still working through what is going wrong. I 
     ## Think it's related to pivot hadamard but I did add a test for that in a different file.
-    Qf,Rf,pf = SEQRCS([cpd[2], cpd[3]], cprank, 2500, 1, 40);
-    error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
+    ## TODO fix this
+    # Qf,Rf,pf = SEQRCS([cpd[2], cpd[3]], cprank, 2500, 1, 40);
+    # error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
 
-    @test_broken abs(error - error_fact) ≤ 1e-2
+    # @test_broken abs(error - error_fact) ≤ 1e-2
 end#

--- a/test/SEQRCS_test.jl
+++ b/test/SEQRCS_test.jl
@@ -53,10 +53,12 @@ end
 
     krpmat = itensor(array(krp, inds(krp)[[3,1,2]]), m,n)
     Q,R,p = SEQRCS(krpmat, 1, m, 2500, 1, 40)
-
     error = norm(array(krpmat)[:,p]-Q[:,1:k]*R[1:k,:],2)/norm(array(krpmat),2)
+    
+    ## For some reason this code fails. Still working through what is going wrong. I 
+    ## Think it's related to pivot hadamard but I did add a test for that in a different file.
     Qf,Rf,pf = SEQRCS([cpd[2], cpd[3]], cprank, 2500, 1, 40);
     error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
 
-    @test abs(error - error_fact) ≤ 1e-2
-end
+    @test_broken abs(error - error_fact) ≤ 1e-2
+end#

--- a/test/SEQRCS_test.jl
+++ b/test/SEQRCS_test.jl
@@ -62,4 +62,23 @@ end
     error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
 
     @test abs(error - error_fact) ≤ 1e-2
+
+    ## Testing order 4 
+    cpd = ITensorCPD.random_CPD(zeros(50, 100, 100, 100), 50)
+
+    cprank = ITensorCPD.cp_rank(cpd)
+    krp = ITensorCPD.had_contract([cpd[1],cpd[3],cpd[4]], cprank)
+
+    n = Index(50 * 100 * 100)
+    krpmat = itensor(array(krp, inds(krp)[[4,1,2,3]]), m,n)
+    Q,R,p = SEQRCS(krpmat, 1, m, 2500, 1, 40)
+    error = norm(array(krpmat)[:,p]-Q[:,1:k]*R[1:k,:],2)/norm(array(krpmat),2)
+    
+    ## For some reason this code fails. Still working through what is going wrong. I 
+    ## Think it's related to pivot hadamard but I did add a test for that in a different file.
+    ## TODO fix this
+    Qf,Rf,pf =  SEQRCS([cpd[1], cpd[3],cpd[4]], cprank, 2500, 1, 40);
+    error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
+
+    @test abs(error - error_fact) ≤ 1e-2
 end#

--- a/test/SEQRCS_test.jl
+++ b/test/SEQRCS_test.jl
@@ -58,8 +58,8 @@ end
     ## For some reason this code fails. Still working through what is going wrong. I 
     ## Think it's related to pivot hadamard but I did add a test for that in a different file.
     ## TODO fix this
-    # Qf,Rf,pf = SEQRCS([cpd[2], cpd[3]], cprank, 2500, 1, 40);
-    # error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
+    Qf,Rf,pf =  SEQRCS([cpd[2], cpd[3]], cprank, 2500, 1, 40);
+    error_fact = norm(array(krpmat)[:,pf]-Qf[:,1:k]*Rf[1:k,:],2)/norm(array(krpmat),2)
 
-    # @test_broken abs(error - error_fact) ≤ 1e-2
+    @test abs(error - error_fact) ≤ 1e-2
 end#

--- a/test/itensor_network_cpd.jl
+++ b/test/itensor_network_cpd.jl
@@ -68,7 +68,7 @@ rng = Random.seed!(Random.RandomDevice())
     opt = nothing
     while check.final_fit < 0.9
         try
-        opt = ITensorCPD.decompose(subtn, Index(2, "rank"); check, verbose = true, rng);
+        opt = ITensorCPD.decompose(subtn, Index(2, "rank"); check, verbose = false, rng);
         fit = check.final_fit
         bestfit = fit > bestfit ? fit : bestfit
         catch

--- a/test/pivot_mapping.jl
+++ b/test/pivot_mapping.jl
@@ -134,7 +134,26 @@ using ITensorCPD: column_to_multi_coords
 
     oh = ITensorCPD.omega_hadamard(cpd.factors[1:end .!=2], cprank, omega)
     exact_had = ITensorCPD.had_contract(cpd.factors[1:end .!= 2], cprank)
-    (omega * reshape(array(exact_had), (3 * 8 * 2, 10)))
     
-    @test_broken norm(array(oh)' - reshape(array(exact_had), (3 * 8 * 2, 10))' * omega') < 1e-12
+    @test norm(array(oh)' - reshape(array(exact_had), (3 * 8 * 2, 10))' * omega') < 1e-12
+
+    A = random_itensor(Index(rand(1:200)), cprank)
+    B = random_itensor(Index(rand(2:200)), cprank)
+
+    ia = dim(A, 1)
+    ib = dim(B, 1)
+
+    n = ia * ib
+    m = dim(cprank)
+    l=Int(round(3 * m * log(m)))
+    s=Int(round(log(m)))
+    vals = Array{Float64}(undef, n * s)
+    rows = Array{Int32}(undef, n * s)
+    omega = ITensorCPD.sparse_sign_matrix(l,n,s, rows, vals; omega=true,injective=false);
+
+    krp = ITensorCPD.had_contract(A,B,cprank)
+    krpm = reshape(array(krp), (ia*ib, m))
+    omega * krpm
+    oh = ITensorCPD.omega_hadamard([A,B], cprank, omega)
+    @test all(array(oh) - omega * krpm .< 1e-10)
 end

--- a/test/pivot_mapping.jl
+++ b/test/pivot_mapping.jl
@@ -62,7 +62,6 @@ using ITensorCPD: column_to_multi_coords
 
     p = [x for x in 1:100*150]
     l = Index(length(p), "Piv")
-    # P = itensor(NDTensors.tensor(Diag(p), (i,j,l,)))
 
     pivs = ITensorCPD.column_to_multi_coords(p, dims((i,j)))
     sampled_had = Array{eltype(B)}(undef, (dim(l), dim(m)))
@@ -95,7 +94,6 @@ using ITensorCPD: column_to_multi_coords
     pivs = ITensorCPD.column_to_multi_coords(p, dims((i,j,k)))
 
     P = itensor(Int, pivs, l, Index(3))
-    #P = itensor(NDTensors.tensor(Diag(p), (i,j,k,l,)))
 
     sampled_had = Array{eltype(B)}(undef, (dim(l), dim(m)))
     for i in 1:dim(l)

--- a/test/pivot_mapping.jl
+++ b/test/pivot_mapping.jl
@@ -62,9 +62,9 @@ using ITensorCPD: column_to_multi_coords
 
     p = [x for x in 1:100*150]
     l = Index(length(p), "Piv")
-    P = itensor(NDTensors.tensor(Diag(p), (i,j,l,)))
+    # P = itensor(NDTensors.tensor(Diag(p), (i,j,l,)))
 
-    pivs = ITensorCPD.column_to_multi_coords(data(P), dim.((i,j)))
+    pivs = ITensorCPD.column_to_multi_coords(p, dims((i,j)))
     sampled_had = Array{eltype(B)}(undef, (dim(l), dim(m)))
     for i in 1:dim(l)
       sampled_had[i,:] = array(exact_had)[pivs[i,1], pivs[i,2], :]
@@ -74,14 +74,14 @@ using ITensorCPD: column_to_multi_coords
 
     p = [rand(1:100*150) for x in 1:40]
     l = Index(length(p), "Piv")
-    P = itensor(NDTensors.tensor(Diag(p), (i,j,l,)))
-
-    pivs = ITensorCPD.column_to_multi_coords(data(P), dim.((i,j)))
+    pivs = column_to_multi_coords(p, dims((i,j)))
+    
     sampled_had = Array{eltype(B)}(undef, (dim(l), dim(m)))
     for i in 1:dim(l)
       sampled_had[i,:] = array(exact_had)[pivs[i,1], pivs[i,2], :]
     end
 
+    P = itensor(Int, pivs, l, Index(2))
     @test norm(array(ITensorCPD.pivot_hadamard(A, B, m, P)) - sampled_had) ≈ 0.0
 
     @test norm(ITensorCPD.pivot_hadamard([A, B], m, P)  - ITensorCPD.pivot_hadamard(A, B, m, P)) ≈ 0.0
@@ -92,12 +92,51 @@ using ITensorCPD: column_to_multi_coords
 
     p = [rand(1:100*150*200) for x in 1:200]
     l = Index(length(p), "Piv")
-    P = itensor(NDTensors.tensor(Diag(p), (i,j,k,l,)))
+    pivs = ITensorCPD.column_to_multi_coords(p, dims((i,j,k)))
 
-    pivs = ITensorCPD.column_to_multi_coords(data(P), dim.((i,j,k)))
+    P = itensor(Int, pivs, l, Index(3))
+    #P = itensor(NDTensors.tensor(Diag(p), (i,j,k,l,)))
+
     sampled_had = Array{eltype(B)}(undef, (dim(l), dim(m)))
     for i in 1:dim(l)
       sampled_had[i,:] = array(exact_had)[pivs[i,1], pivs[i,2], pivs[i,3], :]
     end
     norm(sampled_had - array(ITensorCPD.pivot_hadamard([A, B, C], m, P))) ≈ 0.0
+    @test all(array(ITensorCPD.fused_flatten_sample(exact_had, 4, P)) - sampled_had' .≈ 0)
+
+    p = [rand(1:100*150*200) for x in 1:200]
+    multi = column_to_multi_coords(p, dims((i,j,k)))
+    @test all(p - ITensorCPD.multi_coords_to_column(dims((i,j,k)), multi) .== 0)
+
+    ## Considering sparse matrix sketching
+    cpd = ITensorCPD.random_CPD(T, 10)
+    n = dim(inds(T)[1:end-1])
+    m = dim(T,4)
+    l=Int(round(3 * m * log(m)))
+    s=Int(round(log(m)))
+    vals = Array{Float64}(undef, n * s)
+    rows = Array{Int32}(undef, n * s)
+    omega = ITensorCPD.sparse_sign_matrix(l,n,s, rows, vals; omega=true,injective=false)
+    @test norm(reshape(array(T), n,m)' * omega' - ITensorCPD.sketched_matricization(T, 4, omega)) < 1e-12
+    @test norm(reshape(array(T), n,m)' * omega' - ITensorCPD.sketched_matricization(T, 4, l, rows, vals, s)) < 1e-12
+
+    cprank = ITensorCPD.cp_rank(cpd)
+    oh = ITensorCPD.omega_hadamard(cpd.factors[1:3], cprank, omega)
+    exact_had = ITensorCPD.had_contract(cpd.factors[1:3], cprank)
+    @test norm(array(oh)' - reshape(array(exact_had), (3 * 6 * 8, 10))' * omega') < 1e-12
+
+    
+    n = dim(inds(T)[1:end .!=2])
+    m = dim(T,2)
+    l=Int(round(3 * m * log(m)))
+    s=Int(round(log(m)))
+    vals = Array{Float64}(undef, n * s)
+    rows = Array{Int32}(undef, n * s)
+    omega = ITensorCPD.sparse_sign_matrix(l,n,s, rows, vals; omega=true,injective=false)
+
+    oh = ITensorCPD.omega_hadamard(cpd.factors[1:end .!=2], cprank, omega)
+    exact_had = ITensorCPD.had_contract(cpd.factors[1:end .!= 2], cprank)
+    (omega * reshape(array(exact_had), (3 * 8 * 2, 10)))
+    
+    @test norm(array(oh)' - reshape(array(exact_had), (3 * 8 * 2, 10))' * omega') < 1e-12
 end

--- a/test/pivot_mapping.jl
+++ b/test/pivot_mapping.jl
@@ -138,5 +138,5 @@ using ITensorCPD: column_to_multi_coords
     exact_had = ITensorCPD.had_contract(cpd.factors[1:end .!= 2], cprank)
     (omega * reshape(array(exact_had), (3 * 8 * 2, 10)))
     
-    @test norm(array(oh)' - reshape(array(exact_had), (3 * 8 * 2, 10))' * omega') < 1e-12
+    @test_broken norm(array(oh)' - reshape(array(exact_had), (3 * 8 * 2, 10))' * omega') < 1e-12
 end

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -1,3 +1,18 @@
+function multiple_tries(A, cp_A, exact_error; KWARGS...)
+    for i in 1:10
+        try
+           int_opt_A =
+            als_optimize(A, cp_A; KWARGS...);
+            passed = abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1 
+            return true
+        catch
+            if i == 10
+                return false
+            end
+        end
+    end
+end
+
 @testset "Random CPD-ALS, elt=$elt" for elt in [Float64, ComplexF64]
     verbose = false
     i, j, k = Index.((20, 30, 40))
@@ -67,32 +82,19 @@
         als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
+    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check);
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
+    passed = false
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check)
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
-
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=false);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+        normal=false)
     
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=false, injective=true);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+        normal=false, injective=true, verbose)
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=false, injective=true);
-    @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+        normal=true, injective=true, verbose)
 
     ### Test for Leverage score sampling CPD 
     a,b,c = Index.((12,13,3))

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -82,18 +82,17 @@ end
         als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
-    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check);
+    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check);
 
-    passed = false
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check)
+    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check)
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
         normal=false)
     
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
         normal=false, injective=true, verbose)
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
+    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
         normal=true, injective=true, verbose)
 
     ### Test for Leverage score sampling CPD 

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -4,7 +4,7 @@ function multiple_tries(A, cp_A, exact_error; KWARGS...)
            int_opt_A =
             als_optimize(A, cp_A; KWARGS...);
             passed = abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1 
-            return true
+            return passed
         catch
             if i == 10
                 return false
@@ -13,7 +13,7 @@ function multiple_tries(A, cp_A, exact_error; KWARGS...)
     end
 end
 
-@testset "Random CPD-ALS, elt=$elt" for elt in [Float64, ComplexF64]
+# @testset "Random CPD-ALS, elt=$elt" for elt in [Float64, ComplexF64]
     verbose = false
     i, j, k = Index.((20, 30, 40))
     r = Index(400, "CP_rank")
@@ -79,21 +79,21 @@ end
     exact_error = norm(A - ITensorCPD.reconstruct(opt_A)) / norm(A)
 
     int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
+        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(200), check, verbose=true);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
-    # als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 10), check);
+    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 10), check);
 
-    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check, verbose=true)
 
-    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
-    #     normal=false)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+        normal=false)
     
-    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
-    #     normal=false, injective=true, verbose)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+        normal=false, injective=true, verbose)
 
-    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
-    #     normal=true, injective=true, verbose)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+        normal=true, injective=true, verbose)
 
     ### Test for Leverage score sampling CPD 
     a,b,c = Index.((12,13,3))
@@ -117,7 +117,7 @@ end
     cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, normal=true, verbose);
     @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
 
-    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, normal=true, verbose=true, stop_resample=0);
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, normal=true, verbose, stop_resample=0);
     @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
 
     ### Test for Leverage score sampling CPD 

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -82,18 +82,18 @@ end
         als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected((1,1,1), (1200, 800, 600)), check);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
-    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check);
+    # als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 10), check);
 
-    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check)
+    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check)
 
-    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=false)
+    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
+    #     normal=false)
     
-    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=false, injective=true, verbose)
+    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
+    #     normal=false, injective=true, verbose)
 
-    @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 1), check,
-        normal=true, injective=true, verbose)
+    # @test_broken multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (1200, 800, 600), (1,2,3), 5), check,
+    #     normal=true, injective=true, verbose)
 
     ### Test for Leverage score sampling CPD 
     a,b,c = Index.((12,13,3))
@@ -115,6 +115,9 @@ end
     alg = ITensorCPD.LevScoreSampled(100)
     check = ITensorCPD.CPAngleCheck(1e-5, 10)
     cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, normal=true, verbose);
+    @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
+
+    cpd_opt = ITensorCPD.als_optimize(T, cpd; alg, check, normal=true, verbose=true, stop_resample=0);
     @test norm(reconstruct(cpd_opt) - T) / norm(T) < 0.1
 
     ### Test for Leverage score sampling CPD 
@@ -180,24 +183,24 @@ end
           norm(ITensorCPD.reconstruct(opt_A)) < 1e-1
 
     ## KSEQRCS gets the right answer no problem
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check);
-    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    # int_opt_A =
+    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check);
+    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-        normal=false);
-    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    # int_opt_A =
+    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+    #     normal=false);
+    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
     
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-        normal=false, injective=true);
-    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    # int_opt_A =
+    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+    #     normal=false, injective=true);
+    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
-    int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-        normal=false, injective=true);
-    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    # int_opt_A =
+    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+    #     normal=false, injective=true);
+    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
     ## This tests to see if we can interpolate a known low rank tensor
     A = ITensorCPD.reconstruct(random_CPD(A, 20))

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -13,7 +13,7 @@ function multiple_tries(A, cp_A, exact_error; KWARGS...)
     end
 end
 
-# @testset "Random CPD-ALS, elt=$elt" for elt in [Float64, ComplexF64]
+@testset "Random CPD-ALS, elt=$elt" for elt in [Float64, ComplexF64]
     verbose = false
     i, j, k = Index.((20, 30, 40))
     r = Index(400, "CP_rank")

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -79,20 +79,20 @@ end
     exact_error = norm(A - ITensorCPD.reconstruct(opt_A)) / norm(A)
 
     int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(200), check, verbose);
+        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(1200), check, verbose);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
-    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 10), check);
+    als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1), (1200,), (1,2,3), 10), check);
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check, verbose)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1), (1200,), (1,2,3), 5), check, verbose)
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1), (1200,), (1,2,3), 5), check,
         normal=false)
     
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1), (1200,), (1,2,3), 5), check,
         normal=false, injective=true, verbose)
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1), (1200,), (1,2,3), 5), check,
         normal=true, injective=true, verbose)
 
     ### Test for Leverage score sampling CPD 
@@ -182,25 +182,25 @@ end
     @test norm(ITensorCPD.reconstruct(opt_A) - ITensorCPD.reconstruct(int_opt_A)) /
           norm(ITensorCPD.reconstruct(opt_A)) < 1e-1
 
-    ## KSEQRCS gets the right answer no problem
-    # int_opt_A =
-    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check);
-    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    # KSEQRCS gets the right answer no problem
+    int_opt_A =
+        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check);
+    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
-    # int_opt_A =
-    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-    #     normal=false);
-    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    int_opt_A =
+        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+        normal=false);
+    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
     
-    # int_opt_A =
-    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-    #     normal=false, injective=true);
-    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    int_opt_A =
+        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+        normal=false, injective=true);
+    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
-    # int_opt_A =
-    #     als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
-    #     normal=false, injective=true);
-    # @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
+    int_opt_A =
+        als_optimize(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (400), (1,2,3), 1), check,
+        normal=false, injective=true);
+    @test norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A) < 1e-3
 
     ## This tests to see if we can interpolate a known low rank tensor
     A = ITensorCPD.reconstruct(random_CPD(A, 20))

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -79,12 +79,12 @@ end
     exact_error = norm(A - ITensorCPD.reconstruct(opt_A)) / norm(A)
 
     int_opt_A =
-        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(200), check, verbose=true);
+        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(200), check, verbose);
     @test abs(exact_error - norm(A - ITensorCPD.reconstruct(int_opt_A)) / norm(A)) / exact_error < 0.1
 
     als = ITensorCPD.compute_als(A, cp_A; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 10), check);
 
-    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check, verbose=true)
+    @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check, verbose)
 
     @test multiple_tries(A, cp_A, exact_error; alg = ITensorCPD.KSEQRCSPivProjected((1,1,1), (200, 200, 200), (1,2,3), 5), check,
         normal=false)


### PR DESCRIPTION
To start addressing #30 , we need to migrate sampled indices from matrix based to tensor-index based. This requires the refactoring of major components of the code but overall accuracy should not be modified. This PR does not address the problem with methods like SE-QRCS where row-pivots will be returned in the column-wise notation which can overflow Integer types. This issue also persists in the contraction of sparse count-sketch matrices with the tensors.