### PR TITLE
Improve algorithm naming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorCPD"
 uuid = "8ca0d870-8743-11ef-3aad-a3ebf6911431"
 authors = ["Karl Pierce <kpierce@flatironinstitute.org>"]
-version = "0.0.7"
+version = "0.0.71"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ Currently the library only supports the ALS optimization of tensors and tensor n
 However, the library does support a variety of ALS strategies. The ALS strategy can be modified using the keyword `alg`.
 At the moment the names for these algorithms are under development so please note that they may change in the future to improve the codes readability.
 The most popular ALS algorithm is via the normal equation. This optimizes factors by updating each factor using the gradient of the following loss function `f = 1/2 || T - Tcp ||^2`.
-In the library, there are two algorithms to compute the normal equation `KRP` and `direct`. `KRP` computes the full Khatri-Rao product (KRP) in the construction of the normal equation and `direct` uses tensor products to avoid forming the KRP.
+In the library, there are two algorithms to compute the normal equation `KRPNormal` and `KRPFreeNormal`. `KRP` computes the full Khatri-Rao product (KRP) in the construction of the normal equation and `KRPFreeNormal` uses tensor products to avoid forming the KRP.
 ```julia
 # Form an algorithm
-julia> alg = ITensorCPD.KRP()
+julia> alg = ITensorCPD.KRPNormal()
 julia> cpd = ITensorCPD.decompose(T, 50; alg);
 ## Decomposes the 99% accuracy in 23.991 ms 
 
 # Change the algorithm to direct
-julia> alg = ITensorCPD.direct() 
+julia> alg = ITensorCPD.KRPFreeNormal() 
 julia> cpd = ITensorCPD.decompose(T, 50; alg);
 ## Decomposes the 99% accuracy in 34.609 ms
 ```

--- a/src/algorithms/ALS/standard/tensor.jl
+++ b/src/algorithms/ALS/standard/tensor.jl
@@ -7,9 +7,9 @@ using ITensors.NDTensors.Expose: expose
 ## contracts it with the target tensor. This is relatively expensive because the KRP will be
 ## order $d - 1$ where d is the number of modes in the target tensor.
 ## This process could be distributed.
-struct KRP <: MttkrpAlgorithm end
+struct KRPNormal <: MttkrpAlgorithm end
 
-    function matricize_tensor(::KRP, als, factors, cp, rank::Index, fact::Int)
+    function matricize_tensor(::KRPNormal, als, factors, cp, rank::Index, fact::Int)
 
         factor_portion = @view factors[1:end .!= fact]
         sequence = ITensors.default_sequence()
@@ -19,7 +19,7 @@ struct KRP <: MttkrpAlgorithm end
         return m
     end
 
-    function post_solve(::KRP, als, factors, λ, cp, rank::Index, fact::Integer)
+    function post_solve(::KRPNormal, als, factors, λ, cp, rank::Index, fact::Integer)
         als.additional_items[:part_grammian][fact] =
             factors[fact] * dag(prime(factors[fact]; tags = tags(rank)))
     end
@@ -27,9 +27,9 @@ struct KRP <: MttkrpAlgorithm end
 ## This code skips computing the khatri-rao product by incrementally 
 ## contracting the factor matrices into the tensor for each value of r
 ## This process could be distributed.
-struct direct <: MttkrpAlgorithm end
+struct KRPFreeNormal <: MttkrpAlgorithm end
 
-    function matricize_tensor(::direct, als, factors, cp, rank::Index, fact::Int)
+    function matricize_tensor(::KRPFreeNormal, als, factors, cp, rank::Index, fact::Int)
         factor_portion = @view factors[1:end .!= fact]
         if isnothing(als.additional_items[:mttkrp_contract_sequences][fact])
             als.additional_items[:mttkrp_contract_sequences][fact] =
@@ -43,7 +43,7 @@ struct direct <: MttkrpAlgorithm end
         return m
     end
 
-    function post_solve(::direct, als, factors, λ, cp, rank::Index, fact::Integer) 
+    function post_solve(::KRPFreeNormal, als, factors, λ, cp, rank::Index, fact::Integer) 
         als.additional_items[:part_grammian][fact] .=
             factors[fact] * dag(prime(factors[fact]; tags = tags(rank)))
     end

--- a/src/optimizers/ALS/als.jl
+++ b/src/optimizers/ALS/als.jl
@@ -42,7 +42,7 @@ function compute_als(
     maxiter = nothing,
     kwargs...
 )
-    alg = isnothing(alg) ? direct() : alg
+    alg = isnothing(alg) ? KRPFreeNormal() : alg
     extra_args = Dict();
     check = isnothing(check) ? NoCheck(isnothing(maxiter) ? 100 : maxiter) : check
     mttkrp_contract_sequences = Vector{Union{Any,Nothing}}()

--- a/test/cp_als.jl
+++ b/test/cp_als.jl
@@ -27,19 +27,19 @@
 
     cp_A = random_CPD(A, r)
     ## Optimize with one input
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP());
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal());
     @test norm(reconstruct(opt_A) - A) / norm(A) < 5e-7
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP(), check = ITensorCPD.NoCheck(10))
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal(), check = ITensorCPD.NoCheck(10))
     @test norm(reconstruct(opt_A) - A) / norm(A) < 1e-1
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP(), check)
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal(), check)
     @test norm(ITensorCPD.reconstruct(opt_A) - A) / norm(A) < 1e-5
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct())
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal())
     @test norm(reconstruct(opt_A) - A) / norm(A) < 5e-7
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct(), check, verbose);
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal(), check, verbose);
     @test norm(ITensorCPD.reconstruct(opt_A) - A) / norm(A) < 1e-5
 
     svd_opt_A = als_optimize(A, cp_A; alg = ITensorCPD.TargetDecomp(), check);
@@ -81,19 +81,19 @@ end
     @test norm(reconstruct(opt_A) - A) / norm(A) < 5e-5
 
     ## Optimize with one input
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP())
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal())
     @test norm(reconstruct(opt_A) - A) / norm(A) < 5e-5
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP(), check = ITensorCPD.NoCheck(10))
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal(), check = ITensorCPD.NoCheck(10))
     @test norm(reconstruct(opt_A) - A) / norm(A) < 1e-1
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRP(), check)
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPNormal(), check)
     @test norm(ITensorCPD.reconstruct(opt_A) - A) / norm(A) < 5e-5
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct())
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal())
     @test norm(reconstruct(opt_A) - A) / norm(A) < 5e-5
 
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct(), check)
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal(), check)
     @test norm(ITensorCPD.reconstruct(opt_A) - A) / norm(A) < 5e-5
 
     direct_inversion_opt_A = als_optimize(A, cp_A; alg = ITensorCPD.InvKRP(), check, verbose);

--- a/test/rand_cp_als.jl
+++ b/test/rand_cp_als.jl
@@ -21,7 +21,7 @@
     ITensorCPD.optimize(cp_A, als; verbose);
     
     ## Reference optimization
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct(), check, verbose);
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal(), check, verbose);
 
     int_opt_A =
        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(800), check, verbose, shuffle_pivots=true, trunc_tol=0.001);
@@ -162,7 +162,7 @@ end
 
     ## This method uses the interpolative squared to precondition the problem.
     check = ITensorCPD.FitCheck(1e-6, 100, norm(A))
-    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.direct(), check)
+    opt_A = als_optimize(A, cp_A; alg = ITensorCPD.KRPFreeNormal(), check)
     int_opt_A =
        als_optimize(A, cp_A; alg = ITensorCPD.QRPivProjected(), check, verbose);
     @test norm(ITensorCPD.reconstruct(opt_A) - ITensorCPD.reconstruct(int_opt_A)) /

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, Pkg
 Pkg.develop(path = "$(@__DIR__)/../")
 
 using ITensorCPD:
-    ITensorCPD, als_optimize, direct, random_CPD, row_norm, reconstruct, had_contract
+    ITensorCPD, als_optimize, KRPFreeNormal, random_CPD, row_norm, reconstruct, had_contract
 using ITensors: Index, ITensor, itensor, array, contract, dim, inds, norm, random_itensor
 
 include("./basic_features.jl")


### PR DESCRIPTION
Original algorithms `KRP` and `direct` are ambiguous. Renamed `KRP` to `KRPNormal` and `direct` to `KRPFreeNormal` to be more specific on what is going on behind the scene.